### PR TITLE
fix(riot): use league entries by puuid

### DIFF
--- a/lib/riot/api.ts
+++ b/lib/riot/api.ts
@@ -52,6 +52,19 @@ export type RiotLeagueEntry = {
 };
 
 /**
+ * Obtiene entradas de liga por PUUID.
+ * @param params - Región de plataforma y PUUID.
+ * @returns Entradas de liga.
+ */
+export async function getLeagueEntriesByPuuid(params: {
+  platformRegion: RiotPlatformRegion;
+  puuid: string;
+}) {
+  const url = `https://${params.platformRegion}.api.riotgames.com/lol/league/v4/entries/by-puuid/${params.puuid}`;
+  return riotFetch<RiotLeagueEntry[]>(url);
+}
+
+/**
  * Obtiene cuenta de Riot a partir de Riot ID (gameName + tag).
  * @param params - Región y Riot ID.
  * @returns Cuenta con PUUID.

--- a/lib/riot/sync.ts
+++ b/lib/riot/sync.ts
@@ -6,11 +6,7 @@ import {
   updatePlayerSync,
 } from "@/lib/db/queries";
 import { logger } from "@/lib/logger";
-import {
-  getAccountByRiotId,
-  getLeagueEntriesBySummoner,
-  getSummonerByPuuid,
-} from "@/lib/riot/api";
+import { getAccountByRiotId, getLeagueEntriesByPuuid } from "@/lib/riot/api";
 import {
   accountRegionForPlatform,
   normalizePlatformRegion,
@@ -174,14 +170,9 @@ async function syncPlayer(player: {
       );
     }
 
-    const summoner = await getSummonerByPuuid({
+    const entries = await getLeagueEntriesByPuuid({
       platformRegion,
       puuid,
-    });
-
-    const entries = await getLeagueEntriesBySummoner({
-      platformRegion,
-      summonerId: summoner.id,
     });
 
     const solo = entries.find((entry) => entry.queueType === QUEUE_SOLO);


### PR DESCRIPTION
## Qué cambia\n- Cambia el sync para consultar /league/v4/entries/by-puuid (Riot ya no devuelve summonerId en el endpoint v4).\n\n## Pruebas\n- bun run lint\n- bun run test\n- bun run build\n- bun run test:e2e\n\n## Notas\n- Verificado con Mxgue#TAP (EUW).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Nuevas Características**
  * Se agregó una nueva función de API para obtener entradas de liga utilizando identificadores de jugador directamente.

* **Mejoras de Rendimiento**
  * Optimización del flujo de sincronización que reduce el número de llamadas a servicios externos.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->