### PR TITLE
feat(riot): queue selection + cf headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Migrar un “reto con amigos” que hoy se gestiona en Excel a una **web** despl
   - Crear grupos públicos.
   - Añadir / quitar jugadores (Riot ID + región).
   - Configurar intervalos de sync y cooldown manual.
+  - Seleccionar cola (Solo/Duo o Flex) por jugador.
   - Ejecutar sync manual (respetando cooldown).
-- **Sync automático** desde la API de Riot (Solo/Duo, EUW) usando **cron en GitHub Actions**.
+- **Sync automático** desde la API de Riot (cola configurable, región por jugador) usando **cron en GitHub Actions**.
 - Métricas derivadas: `winrate` y `games` se calculan a partir de `wins/losses`.
 
 ## Rutas clave
@@ -70,6 +71,8 @@ Migrar un “reto con amigos” que hoy se gestiona en Excel a una **web** despl
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
 - `CLERK_SECRET_KEY`
 - `RIOT_API_KEY`
+- `RIOT_USER_AGENT` (opcional, default Chrome UA para evitar 403/1010)
+- `RIOT_ACCEPT_LANGUAGE` (opcional)
 - `CRON_SECRET` (opcional, si quieres proteger `/api/sync` con token)
 - `CRON_SYNC_URL` (opcional, URL usada por GitHub Actions para el cron)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Migrar un “reto con amigos” que hoy se gestiona en Excel a una **web** despl
 ## MVP actual
 - **Home pública** con listado de **grupos públicos**.
 - **Página de grupo** `/g/[slug]` con tabla read-only y ordenación (winrate, rango, LP, actualización).
+- **Sync público** en `/g/[slug]` con botón manual (cooldown 1 min).
 - **Panel admin** `/admin` con **Clerk** para:
   - Crear grupos públicos.
   - Añadir / quitar jugadores (Riot ID + región).

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -126,6 +126,7 @@ export async function addPlayerAction(formData: FormData) {
     gameName: formData.get("gameName"),
     tagLine: formData.get("tagLine"),
     region: formData.get("region"),
+    queueType: formData.get("queueType"),
   });
 
   await assertGroupAccess({ userId, groupId: parsed.groupId });
@@ -143,6 +144,7 @@ export async function addPlayerAction(formData: FormData) {
       gameName: parsed.gameName,
       tagLine: parsed.tagLine,
       region,
+      queueType: parsed.queueType,
       opggUrl: `https://www.op.gg/summoners/${opggRegion(region)}/${encodeURIComponent(
         `${parsed.gameName}-${parsed.tagLine}`,
       )}`,

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -41,7 +41,7 @@ async function requireUser() {
   }
 
   const user = await currentUser();
-  const email = user?.primaryEmailAddress?.emailAddress ?? null;
+  const email = user?.primaryEmailAddress?.emailAddress ?? undefined;
   await ensureUser({
     id: userId,
     email,

--- a/app/admin/groups-table.tsx
+++ b/app/admin/groups-table.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { addPlayerAction } from "@/app/admin/actions";
+import { QUEUE_OPTIONS } from "@/lib/riot/queues";
+import { PLATFORM_REGION_OPTIONS } from "@/lib/riot/regions";
+
+type GroupSummary = {
+  id: string;
+  name: string;
+  slug: string;
+  playersCount: number;
+  syncIntervalMinutes: number | null;
+};
+
+type GroupsTableProps = {
+  groups: GroupSummary[];
+};
+
+export function GroupsTable({ groups }: GroupsTableProps) {
+  const [selectedGroup, setSelectedGroup] = useState<GroupSummary | null>(null);
+
+  const hasGroups = groups.length > 0;
+  const groupRows = useMemo(() => groups, [groups]);
+
+  return (
+    <div className="space-y-4">
+      {!hasGroups ? (
+        <p className="text-sm text-gray-500">
+          Crea un grupo para añadir jugadores.
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-gray-200">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-3">Grupo</th>
+                <th className="px-4 py-3">Slug</th>
+                <th className="px-4 py-3">Jugadores</th>
+                <th className="px-4 py-3">Sync (min)</th>
+                <th className="px-4 py-3 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 bg-white">
+              {groupRows.map((group) => (
+                <tr key={group.id} className="text-gray-700">
+                  <td className="px-4 py-3 font-medium text-gray-900">
+                    {group.name}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-gray-500">
+                    /{group.slug}
+                  </td>
+                  <td className="px-4 py-3">{group.playersCount}</td>
+                  <td className="px-4 py-3">
+                    {group.syncIntervalMinutes ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      className="rounded-md border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700 transition hover:border-gray-900 hover:text-gray-900"
+                      onClick={() => setSelectedGroup(group)}
+                    >
+                      Añadir jugador
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selectedGroup ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center px-4"
+        >
+          <button
+            type="button"
+            aria-label="Cerrar modal"
+            className="absolute inset-0 bg-gray-900/40"
+            onClick={() => setSelectedGroup(null)}
+          />
+          <div className="relative w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold text-gray-900">
+                Añadir jugador
+              </h3>
+              <p className="text-xs text-gray-500">
+                Grupo: {selectedGroup.name}
+              </p>
+            </div>
+            <form action={addPlayerAction} className="mt-4 grid gap-4">
+              <input type="hidden" name="groupId" value={selectedGroup.id} />
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label
+                    htmlFor="modal-game-name"
+                    className="text-xs font-medium text-gray-500"
+                  >
+                    Riot ID
+                  </label>
+                  <input
+                    id="modal-game-name"
+                    name="gameName"
+                    required
+                    className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+                    placeholder="GameName"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="modal-tag-line"
+                    className="text-xs font-medium text-gray-500"
+                  >
+                    Tag
+                  </label>
+                  <input
+                    id="modal-tag-line"
+                    name="tagLine"
+                    required
+                    className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+                    placeholder="EUW"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label
+                    htmlFor="modal-queue"
+                    className="text-xs font-medium text-gray-500"
+                  >
+                    Cola
+                  </label>
+                  <select
+                    id="modal-queue"
+                    name="queueType"
+                    className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+                    defaultValue="RANKED_SOLO_5x5"
+                  >
+                    {QUEUE_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label
+                    htmlFor="modal-region"
+                    className="text-xs font-medium text-gray-500"
+                  >
+                    Región
+                  </label>
+                  <select
+                    id="modal-region"
+                    name="region"
+                    className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+                    defaultValue="euw1"
+                  >
+                    {PLATFORM_REGION_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700"
+                  onClick={() => setSelectedGroup(null)}
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white"
+                >
+                  Guardar jugador
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -7,8 +7,10 @@ import {
   updateGroupSettingsAction,
 } from "@/app/admin/actions";
 import { GroupsTable } from "@/app/admin/groups-table";
+import { isAdminEmail } from "@/lib/auth/admin";
 import {
   ensureUser,
+  getAllGroups,
   getGroupPlayers,
   getGroupsForUser,
 } from "@/lib/db/queries";
@@ -21,12 +23,16 @@ export default async function AdminPage() {
   }
 
   const user = await currentUser();
+  const email = user?.primaryEmailAddress?.emailAddress ?? null;
   await ensureUser({
     id: userId,
-    email: user?.primaryEmailAddress?.emailAddress,
+    email,
   });
 
-  const groups = await getGroupsForUser(userId);
+  const isAdmin = isAdminEmail(email);
+  const groups = isAdmin
+    ? await getAllGroups()
+    : await getGroupsForUser(userId);
   const playersByGroup = new Map<
     string,
     Awaited<ReturnType<typeof getGroupPlayers>>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -82,7 +82,8 @@ export default async function AdminPage() {
                 id="group-sync-interval"
                 name="syncIntervalMinutes"
                 type="number"
-                min={15}
+                min={0.5}
+                step={0.5}
                 max={1440}
                 defaultValue={360}
                 className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
@@ -180,7 +181,8 @@ export default async function AdminPage() {
                     id={syncId}
                     name="syncIntervalMinutes"
                     type="number"
-                    min={15}
+                    min={0.5}
+                    step={0.5}
                     max={1440}
                     defaultValue={group.syncIntervalMinutes ?? 360}
                     className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -23,7 +23,7 @@ export default async function AdminPage() {
   }
 
   const user = await currentUser();
-  const email = user?.primaryEmailAddress?.emailAddress ?? null;
+  const email = user?.primaryEmailAddress?.emailAddress ?? undefined;
   await ensureUser({
     id: userId,
     email,

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,19 +1,18 @@
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import {
-  addPlayerAction,
   createGroupAction,
   manualSyncGroupAction,
   removePlayerAction,
   updateGroupSettingsAction,
 } from "@/app/admin/actions";
+import { GroupsTable } from "@/app/admin/groups-table";
 import {
   ensureUser,
   getGroupPlayers,
   getGroupsForUser,
 } from "@/lib/db/queries";
-import { getQueueLabel, QUEUE_OPTIONS } from "@/lib/riot/queues";
-import { PLATFORM_REGION_OPTIONS } from "@/lib/riot/regions";
+import { getQueueLabel } from "@/lib/riot/queues";
 
 export default async function AdminPage() {
   const { userId } = await auth();
@@ -116,110 +115,25 @@ export default async function AdminPage() {
         </section>
 
         <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h2 className="text-lg font-semibold text-gray-900">
-            Añadir jugador
-          </h2>
-          <form
-            action={addPlayerAction}
-            className="mt-4 grid gap-4 sm:grid-cols-6"
-          >
-            <div className="sm:col-span-2">
-              <label
-                htmlFor="player-group"
-                className="text-xs font-medium text-gray-500"
-              >
-                Grupo
-              </label>
-              <select
-                id="player-group"
-                name="groupId"
-                className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
-                required
-              >
-                {groups.map((group) => (
-                  <option key={group.id} value={group.id}>
-                    {group.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <label
-                htmlFor="player-game-name"
-                className="text-xs font-medium text-gray-500"
-              >
-                Riot ID
-              </label>
-              <input
-                id="player-game-name"
-                name="gameName"
-                required
-                className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
-                placeholder="GameName"
-              />
+              <h2 className="text-lg font-semibold text-gray-900">Grupos</h2>
+              <p className="text-sm text-gray-600">
+                Selecciona un grupo para añadir jugadores.
+              </p>
             </div>
-            <div>
-              <label
-                htmlFor="player-tag"
-                className="text-xs font-medium text-gray-500"
-              >
-                Tag
-              </label>
-              <input
-                id="player-tag"
-                name="tagLine"
-                required
-                className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
-                placeholder="EUW"
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="player-queue"
-                className="text-xs font-medium text-gray-500"
-              >
-                Cola
-              </label>
-              <select
-                id="player-queue"
-                name="queueType"
-                className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
-                defaultValue="RANKED_SOLO_5x5"
-              >
-                {QUEUE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label
-                htmlFor="player-region"
-                className="text-xs font-medium text-gray-500"
-              >
-                Región
-              </label>
-              <select
-                id="player-region"
-                name="region"
-                className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
-                defaultValue="euw1"
-              >
-                {PLATFORM_REGION_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <button
-              type="submit"
-              className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white sm:col-span-6 sm:w-fit"
-            >
-              Añadir jugador
-            </button>
-          </form>
+          </div>
+          <div className="mt-4">
+            <GroupsTable
+              groups={groups.map((group) => ({
+                id: group.id,
+                name: group.name,
+                slug: group.slug,
+                playersCount: playersByGroup.get(group.id)?.length ?? 0,
+                syncIntervalMinutes: group.syncIntervalMinutes ?? null,
+              }))}
+            />
+          </div>
         </section>
 
         {groups.map((group) => {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -12,6 +12,8 @@ import {
   getGroupPlayers,
   getGroupsForUser,
 } from "@/lib/db/queries";
+import { getQueueLabel, QUEUE_OPTIONS } from "@/lib/riot/queues";
+import { PLATFORM_REGION_OPTIONS } from "@/lib/riot/regions";
 
 export default async function AdminPage() {
   const { userId } = await auth();
@@ -119,7 +121,7 @@ export default async function AdminPage() {
           </h2>
           <form
             action={addPlayerAction}
-            className="mt-4 grid gap-4 sm:grid-cols-5"
+            className="mt-4 grid gap-4 sm:grid-cols-6"
           >
             <div className="sm:col-span-2">
               <label
@@ -173,6 +175,26 @@ export default async function AdminPage() {
             </div>
             <div>
               <label
+                htmlFor="player-queue"
+                className="text-xs font-medium text-gray-500"
+              >
+                Cola
+              </label>
+              <select
+                id="player-queue"
+                name="queueType"
+                className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
+                defaultValue="RANKED_SOLO_5x5"
+              >
+                {QUEUE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label
                 htmlFor="player-region"
                 className="text-xs font-medium text-gray-500"
               >
@@ -184,12 +206,16 @@ export default async function AdminPage() {
                 className="mt-1 w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
                 defaultValue="euw1"
               >
-                <option value="euw1">EUW</option>
+                {PLATFORM_REGION_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
               </select>
             </div>
             <button
               type="submit"
-              className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white sm:col-span-5 sm:w-fit"
+              className="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white sm:col-span-6 sm:w-fit"
             >
               Añadir jugador
             </button>
@@ -289,8 +315,9 @@ export default async function AdminPage() {
                             {player.gameName}#{player.tagLine}
                           </div>
                           <div className="text-xs text-gray-500">
-                            {player.region.toUpperCase()} · {player.tier ?? "—"}{" "}
-                            {player.division ?? ""}
+                            {player.region.toUpperCase()} ·{" "}
+                            {getQueueLabel(player.queueType)} ·{" "}
+                            {player.tier ?? "—"} {player.division ?? ""}
                           </div>
                         </div>
                         <form action={removePlayerAction}>

--- a/app/g/[slug]/actions.ts
+++ b/app/g/[slug]/actions.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  getGroupSyncSettings,
+  getPublicGroupById,
+  touchGroupManualSync,
+} from "@/lib/db/queries";
+import { logger } from "@/lib/logger";
+import { syncGroupPlayers } from "@/lib/riot/sync";
+import { isPast } from "@/lib/utils/time";
+
+const PUBLIC_SYNC_COOLDOWN_MINUTES = 1;
+
+/**
+ * Ejecuta un sync público para un grupo (cooldown 1 minuto).
+ * @param formData - FormData con groupId.
+ */
+export async function publicSyncGroupAction(formData: FormData) {
+  const groupId = formData.get("groupId");
+  if (typeof groupId !== "string" || !groupId) {
+    return;
+  }
+
+  const group = await getPublicGroupById(groupId);
+  if (!group) {
+    logger.warn("Public sync denied (group not public)", { groupId });
+    return;
+  }
+
+  const settings = await getGroupSyncSettings(groupId);
+  if (!settings) {
+    return;
+  }
+
+  const allowed = isPast({
+    timestamp: settings.lastManualSyncAt,
+    minMinutes: PUBLIC_SYNC_COOLDOWN_MINUTES,
+  });
+
+  if (!allowed) {
+    logger.info("Public sync cooldown not elapsed", { groupId });
+    return;
+  }
+
+  await syncGroupPlayers({ groupId, force: true, limit: 5 });
+  await touchGroupManualSync({ groupId });
+  revalidatePath(`/g/${group.slug}`);
+}

--- a/app/g/[slug]/page.tsx
+++ b/app/g/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { publicSyncGroupAction } from "@/app/g/[slug]/actions";
 import { PlayersTable } from "@/components/players/players-table";
 import { getGroupBySlug } from "@/lib/db/queries";
 
@@ -59,7 +60,17 @@ export default async function GroupPage({
               ))}
             </div>
           </div>
+          <form action={publicSyncGroupAction} className="flex items-center">
+            <input type="hidden" name="groupId" value={data.group.id} />
+            <button
+              type="submit"
+              className="rounded-md border border-gray-200 bg-white px-3 py-2 text-xs font-medium text-gray-700"
+            >
+              Actualizar ahora
+            </button>
+          </form>
         </div>
+        <p className="text-xs text-gray-500">Cooldown público: 1 minuto.</p>
 
         <PlayersTable
           players={data.players.map((player) => ({

--- a/app/g/[slug]/page.tsx
+++ b/app/g/[slug]/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { publicSyncGroupAction } from "@/app/g/[slug]/actions";
+import { PublicSyncButton } from "@/app/g/[slug]/public-sync-button";
 import { PlayersTable } from "@/components/players/players-table";
 import { getGroupBySlug } from "@/lib/db/queries";
-import { isPast, minutesToMs } from "@/lib/utils/time";
 
 export const dynamic = "force-dynamic";
 
@@ -24,18 +24,6 @@ export default async function GroupPage({
   }
 
   const publicCooldownMinutes = 1;
-  const canSync = isPast({
-    timestamp: data.group.lastManualSyncAt,
-    minMinutes: publicCooldownMinutes,
-  });
-  const remainingMs = data.group.lastManualSyncAt
-    ? Math.max(
-        0,
-        minutesToMs(publicCooldownMinutes) -
-          (Date.now() - Date.parse(data.group.lastManualSyncAt)),
-      )
-    : 0;
-  const remainingSeconds = Math.ceil(remainingMs / 1000);
   const sort = normalizeSort(resolvedSearchParams?.sort);
   const sortOptions = [
     { value: "winrate", label: "Winrate" },
@@ -76,19 +64,10 @@ export default async function GroupPage({
           </div>
           <form action={publicSyncGroupAction} className="flex items-center">
             <input type="hidden" name="groupId" value={data.group.id} />
-            <button
-              type="submit"
-              disabled={!canSync}
-              className={`rounded-md border px-3 py-2 text-xs font-medium transition ${
-                canSync
-                  ? "border-gray-200 bg-white text-gray-700 hover:border-gray-900 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/20"
-                  : "cursor-not-allowed border-gray-100 bg-gray-100 text-gray-400"
-              }`}
-            >
-              {canSync
-                ? "Actualizar ahora"
-                : `Disponible en ${remainingSeconds}s`}
-            </button>
+            <PublicSyncButton
+              lastManualSyncAt={data.group.lastManualSyncAt}
+              cooldownMinutes={publicCooldownMinutes}
+            />
           </form>
         </div>
         <p className="text-xs text-gray-500">Cooldown público: 1 minuto.</p>

--- a/app/g/[slug]/page.tsx
+++ b/app/g/[slug]/page.tsx
@@ -79,9 +79,9 @@ export default async function GroupPage({
             <button
               type="submit"
               disabled={!canSync}
-              className={`rounded-md border px-3 py-2 text-xs font-medium ${
+              className={`rounded-md border px-3 py-2 text-xs font-medium transition ${
                 canSync
-                  ? "border-gray-200 bg-white text-gray-700"
+                  ? "border-gray-200 bg-white text-gray-700 hover:border-gray-900 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/20"
                   : "cursor-not-allowed border-gray-100 bg-gray-100 text-gray-400"
               }`}
             >

--- a/app/g/[slug]/public-sync-button.tsx
+++ b/app/g/[slug]/public-sync-button.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type PublicSyncButtonProps = {
+  lastManualSyncAt: string | null;
+  cooldownMinutes: number;
+};
+
+function getRemainingSeconds(params: {
+  lastManualSyncAt: string | null;
+  cooldownMinutes: number;
+}) {
+  if (!params.lastManualSyncAt) {
+    return 0;
+  }
+  const last = Date.parse(params.lastManualSyncAt);
+  if (Number.isNaN(last)) {
+    return 0;
+  }
+  const cooldownMs = params.cooldownMinutes * 60 * 1000;
+  const remainingMs = cooldownMs - (Date.now() - last);
+  return Math.max(0, Math.ceil(remainingMs / 1000));
+}
+
+export function PublicSyncButton({
+  lastManualSyncAt,
+  cooldownMinutes,
+}: PublicSyncButtonProps) {
+  const [remainingSeconds, setRemainingSeconds] = useState(() =>
+    getRemainingSeconds({ lastManualSyncAt, cooldownMinutes }),
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRemainingSeconds(
+        getRemainingSeconds({ lastManualSyncAt, cooldownMinutes }),
+      );
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [lastManualSyncAt, cooldownMinutes]);
+
+  const canSync = remainingSeconds === 0;
+  const label = useMemo(() => {
+    if (canSync) {
+      return "Actualizar ahora";
+    }
+    return `Disponible en ${remainingSeconds}s`;
+  }, [canSync, remainingSeconds]);
+
+  return (
+    <button
+      type="submit"
+      disabled={!canSync}
+      className={`rounded-md border px-3 py-2 text-xs font-medium transition ${
+        canSync
+          ? "border-gray-200 bg-white text-gray-700 hover:border-gray-900 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900/20"
+          : "cursor-not-allowed border-gray-100 bg-gray-100 text-gray-400"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -64,6 +64,7 @@ Proyecto Next.js (App Router) para el reto LoL. Usa Turso + Drizzle para datos y
 - Manual sync desde `/admin` con cooldown configurable.
 - Cola y región seleccionables desde admin (cola por jugador).
 - Reintentos con backoff cuando hay rate limit (429).
+- Botón público en `/g/[slug]` (cooldown 1 min).
 
 ## Screenshots (Playwright)
 - Ejecutar: `node scripts/capture-screens.mjs`

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -14,7 +14,7 @@ Proyecto Next.js (App Router) para el reto LoL. Usa Turso + Drizzle para datos y
 - `components/players/players-table.tsx` — tabla + cards mobile
 - `lib/db/` — cliente, schema y queries (Drizzle)
   - `migrations/` — migraciones generadas
-- `lib/riot/` — API, regiones y lógica de sync
+- `lib/riot/` — API, regiones, colas y lógica de sync
 - `lib/players/` — métricas y ranking
 - `lib/utils/` — helpers (slug/time)
 - `docs/screenshots/` — capturas UI (Playwright)
@@ -38,6 +38,8 @@ Proyecto Next.js (App Router) para el reto LoL. Usa Turso + Drizzle para datos y
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`
 - `CLERK_SECRET_KEY`
 - `RIOT_API_KEY`
+- `RIOT_USER_AGENT` (opcional, default Chrome UA para evitar 403/1010)
+- `RIOT_ACCEPT_LANGUAGE` (opcional)
 - `CRON_SECRET` (opcional)
 - `CRON_SYNC_URL` (opcional, URL usada por GitHub Actions para el cron)
 
@@ -60,6 +62,8 @@ Proyecto Next.js (App Router) para el reto LoL. Usa Turso + Drizzle para datos y
 - Cron en GitHub Actions cada 10 minutos.
 - Sync incremental por lotes (no actualiza todo a la vez).
 - Manual sync desde `/admin` con cooldown configurable.
+- Cola y región seleccionables desde admin (cola por jugador).
+- Reintentos con backoff cuando hay rate limit (429).
 
 ## Screenshots (Playwright)
 - Ejecutar: `node scripts/capture-screens.mjs`

--- a/lib/auth/admin.ts
+++ b/lib/auth/admin.ts
@@ -1,0 +1,24 @@
+const adminEmails = (process.env.ADMIN_EMAILS ?? "")
+  .split(",")
+  .map((email) => email.trim().toLowerCase())
+  .filter(Boolean);
+
+/**
+ * Devuelve true si existe allowlist de admin.
+ */
+export function hasAdminAllowlist() {
+  return adminEmails.length > 0;
+}
+
+/**
+ * Determina si un email tiene permisos de admin.
+ * Si no hay allowlist configurada, se considera admin.
+ * @param email - Email del usuario.
+ */
+export function isAdminEmail(email?: string | null) {
+  if (!hasAdminAllowlist()) {
+    return true;
+  }
+  const normalizedEmail = (email ?? "").toLowerCase().trim();
+  return normalizedEmail ? adminEmails.includes(normalizedEmail) : false;
+}

--- a/lib/db/migrations/0001_add_queue_type.sql
+++ b/lib/db/migrations/0001_add_queue_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `players` ADD COLUMN `queue_type` text DEFAULT 'RANKED_SOLO_5x5' NOT NULL;

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1769963372625,
       "tag": "0000_motionless_chat",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1770049708552,
+      "tag": "0001_add_queue_type",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -189,6 +189,26 @@ export async function getGroupBySlug(slug: string) {
 }
 
 /**
+ * Obtiene un grupo público por ID (sin jugadores).
+ * @param groupId - ID del grupo.
+ * @returns Grupo público o null.
+ */
+export async function getPublicGroupById(groupId: string) {
+  if (!isDbConfigured()) {
+    return null;
+  }
+
+  return db.query.groups.findFirst({
+    where: and(eq(groups.id, groupId), eq(groups.isPublic, true)),
+    columns: {
+      id: true,
+      slug: true,
+      isPublic: true,
+    },
+  });
+}
+
+/**
  * Crea un grupo y registra al owner como miembro.
  * @param params - Datos de creación del grupo.
  * @returns El grupo creado.

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -283,6 +283,7 @@ export async function createPlayer(params: {
   gameName: string;
   tagLine: string;
   region: string;
+  queueType?: string;
   opggUrl?: string;
 }) {
   await db.insert(players).values({
@@ -290,6 +291,7 @@ export async function createPlayer(params: {
     gameName: params.gameName,
     tagLine: params.tagLine,
     region: params.region,
+    queueType: params.queueType ?? "RANKED_SOLO_5x5",
     opggUrl: params.opggUrl,
   });
 
@@ -343,6 +345,7 @@ export async function getGroupPlayers(groupId: string) {
       gameName: players.gameName,
       tagLine: players.tagLine,
       region: players.region,
+      queueType: players.queueType,
       puuid: players.puuid,
       opggUrl: players.opggUrl,
       tier: players.tier,
@@ -371,6 +374,7 @@ export async function getPlayersForSync() {
       gameName: players.gameName,
       tagLine: players.tagLine,
       region: players.region,
+      queueType: players.queueType,
       puuid: players.puuid,
       lastSyncAt: players.lastSyncAt,
       groupId: groupPlayers.groupId,

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -133,6 +133,20 @@ export async function getGroupsForUser(userId: string) {
     .orderBy(desc(groups.createdAt));
 }
 
+/**
+ * Lista todos los grupos (solo para admin).
+ * @returns Todos los grupos.
+ */
+export async function getAllGroups() {
+  if (!isDbConfigured()) {
+    return [];
+  }
+
+  return db.query.groups.findMany({
+    orderBy: desc(groups.createdAt),
+  });
+}
+
 function orOwnerOrMember(params: { userId: string }) {
   return sql`(${groups.ownerId} = ${params.userId} OR ${groupMembers.userId} = ${params.userId})`;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -70,6 +70,7 @@ export const players = sqliteTable(
     gameName: text("game_name").notNull(),
     tagLine: text("tag_line").notNull(),
     region: text("region").notNull(),
+    queueType: text("queue_type").notNull().default("RANKED_SOLO_5x5"),
     puuid: text("puuid"),
     opggUrl: text("opgg_url"),
     tier: text("tier"),

--- a/lib/riot/queues.ts
+++ b/lib/riot/queues.ts
@@ -1,0 +1,22 @@
+export const QUEUE_OPTIONS = [
+  { value: "RANKED_SOLO_5x5", label: "Solo/Duo" },
+  { value: "RANKED_FLEX_SR", label: "Flex 5v5" },
+] as const;
+
+export type RiotQueueType = (typeof QUEUE_OPTIONS)[number]["value"];
+
+const queueLabelMap = new Map<RiotQueueType, string>(
+  QUEUE_OPTIONS.map((option) => [option.value, option.label]),
+);
+
+/**
+ * Devuelve el label legible de una cola.
+ * @param queueType - Cola de ranked.
+ * @returns Label para UI.
+ */
+export function getQueueLabel(queueType: string | null | undefined) {
+  if (!queueType) {
+    return "Solo/Duo";
+  }
+  return queueLabelMap.get(queueType as RiotQueueType) ?? "Solo/Duo";
+}

--- a/lib/riot/regions.ts
+++ b/lib/riot/regions.ts
@@ -1,14 +1,84 @@
-export type RiotPlatformRegion = "euw1";
-export type RiotAccountRegion = "europe";
+export type RiotPlatformRegion =
+  | "euw1"
+  | "eun1"
+  | "na1"
+  | "kr"
+  | "jp1"
+  | "br1"
+  | "la1"
+  | "la2"
+  | "oc1"
+  | "tr1"
+  | "ru";
+export type RiotAccountRegion = "americas" | "europe" | "asia";
 
 const platformMap: Record<string, RiotPlatformRegion> = {
   euw: "euw1",
   euw1: "euw1",
+  eune: "eun1",
+  eun1: "eun1",
+  na: "na1",
+  na1: "na1",
+  kr: "kr",
+  jp: "jp1",
+  jp1: "jp1",
+  br: "br1",
+  br1: "br1",
+  lan: "la1",
+  la1: "la1",
+  las: "la2",
+  la2: "la2",
+  oce: "oc1",
+  oc1: "oc1",
+  tr: "tr1",
+  tr1: "tr1",
+  ru: "ru",
+};
+
+const accountRegionMap: Record<RiotPlatformRegion, RiotAccountRegion> = {
+  euw1: "europe",
+  eun1: "europe",
+  tr1: "europe",
+  ru: "europe",
+  na1: "americas",
+  br1: "americas",
+  la1: "americas",
+  la2: "americas",
+  oc1: "americas",
+  kr: "asia",
+  jp1: "asia",
 };
 
 const opggRegionMap: Record<RiotPlatformRegion, string> = {
   euw1: "euw",
+  eun1: "eune",
+  na1: "na",
+  kr: "kr",
+  jp1: "jp",
+  br1: "br",
+  la1: "lan",
+  la2: "las",
+  oc1: "oce",
+  tr1: "tr",
+  ru: "ru",
 };
+
+export const PLATFORM_REGION_OPTIONS: Array<{
+  value: RiotPlatformRegion;
+  label: string;
+}> = [
+  { value: "euw1", label: "EUW" },
+  { value: "eun1", label: "EUNE" },
+  { value: "na1", label: "NA" },
+  { value: "kr", label: "KR" },
+  { value: "jp1", label: "JP" },
+  { value: "br1", label: "BR" },
+  { value: "la1", label: "LAN" },
+  { value: "la2", label: "LAS" },
+  { value: "oc1", label: "OCE" },
+  { value: "tr1", label: "TR" },
+  { value: "ru", label: "RU" },
+];
 
 /**
  * Normaliza y mapea una región a RiotPlatformRegion.
@@ -31,9 +101,9 @@ export function normalizePlatformRegion(input: string): RiotPlatformRegion {
  * @returns Región de cuenta.
  */
 export function accountRegionForPlatform(
-  _region: RiotPlatformRegion,
+  region: RiotPlatformRegion,
 ): RiotAccountRegion {
-  return "europe";
+  return accountRegionMap[region] ?? "europe";
 }
 
 /**

--- a/lib/validations/admin.ts
+++ b/lib/validations/admin.ts
@@ -3,13 +3,13 @@ import { z } from "zod";
 
 export const createGroupSchema = z.object({
   name: z.string().min(2),
-  syncIntervalMinutes: z.coerce.number().min(15).max(1440).default(360),
+  syncIntervalMinutes: z.coerce.number().min(0.5).max(1440).default(360),
   manualCooldownMinutes: z.coerce.number().min(5).max(240).default(30),
 });
 
 export const settingsSchema = z.object({
   groupId: z.string().min(1),
-  syncIntervalMinutes: z.coerce.number().min(15).max(1440),
+  syncIntervalMinutes: z.coerce.number().min(0.5).max(1440),
   manualCooldownMinutes: z.coerce.number().min(5).max(240),
 });
 

--- a/lib/validations/admin.ts
+++ b/lib/validations/admin.ts
@@ -18,6 +18,9 @@ export const playerSchema = z.object({
   gameName: z.string().min(2),
   tagLine: z.string().min(2),
   region: z.string().min(2),
+  queueType: z
+    .enum(["RANKED_SOLO_5x5", "RANKED_FLEX_SR"])
+    .default("RANKED_SOLO_5x5"),
 });
 
 export const removePlayerSchema = z.object({

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { type NextRequest, NextResponse } from "next/server";
-import { hasAdminAllowlist, isAdminEmail } from "@/lib/auth/admin";
 
 const isProtectedRoute = createRouteMatcher(["/admin(.*)"]);
 const screenshotMode = process.env.SCREENSHOT_MODE === "true";
@@ -17,15 +16,7 @@ const middleware = screenshotMode
         return;
       }
 
-      const authObject = await auth.protect();
-      if (!hasAdminAllowlist()) {
-        return;
-      }
-
-      const email = authObject.sessionClaims?.email;
-      if (!isAdminEmail(typeof email === "string" ? email : null)) {
-        return NextResponse.redirect(new URL("/", req.url));
-      }
+      await auth.protect();
     });
 
 export default middleware;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const port = process.env.PLAYWRIGHT_PORT ?? "3002";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: "./tests-e2e",
   timeout: 30_000,
@@ -8,12 +11,12 @@ export default defineConfig({
   },
   retries: process.env.CI ? 1 : 0,
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL,
     trace: "on-first-retry",
   },
   webServer: {
-    command: "bun run dev",
-    url: "http://127.0.0.1:3000",
+    command: `PORT=${port} bun run dev`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/tests/regions.test.ts
+++ b/tests/regions.test.ts
@@ -15,4 +15,14 @@ describe("riot regions", () => {
     expect(accountRegionForPlatform(platform)).toBe("europe");
     expect(opggRegion(platform)).toBe("euw");
   });
+
+  it("maps NA and EUNE", () => {
+    expect(normalizePlatformRegion("na")).toBe("na1");
+    expect(accountRegionForPlatform("na1")).toBe("americas");
+    expect(opggRegion("na1")).toBe("na");
+
+    expect(normalizePlatformRegion("eune")).toBe("eun1");
+    expect(accountRegionForPlatform("eun1")).toBe("europe");
+    expect(opggRegion("eun1")).toBe("eune");
+  });
 });


### PR DESCRIPTION
## Summary
- add queue selection per player and show queue in admin
- add Cloudflare-friendly headers + rate-limit retry for Riot API
- add public sync button on group page with cooldown state (1 min)
- improve public sync button affordance (hover/disabled)
- live countdown for public cooldown
- replace admin add-player form with group table + modal
- allow 30s minimum sync interval for new groups
- add queue_type migration and Playwright configurable port

## Testing
- bun run lint
- bun run test
- bun run build
- bun run test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Notas de Versión

* **New Features**
  * Sincronización manual pública de grupos con botón y cooldown de 1 minuto.
  * Selección de cola por jugador (Solo/Dúo o Flex) y visualización de la cola en la interfaz.
  * Administradores pueden ver y gestionar todas las agrupaciones desde el panel.

* **Bug Fixes**
  * Manejo de límites de la API con reintentos y backoff; respetuoso con cabeceras de rate-limit.

* **Chores**
  * Nuevas opciones de región soportadas.
  * Añadidas variables de entorno opcionales para personalizar la integración con Riot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->