### PR TITLE
fix(sync): remove limit:5 on manual sync + add observability logs

### DIFF
--- a/app/g/[slug]/actions.ts
+++ b/app/g/[slug]/actions.ts
@@ -48,7 +48,18 @@ export async function publicSyncGroupAction(formData: FormData) {
     return;
   }
 
-  await syncGroupPlayers({ groupId, force: true, limit: 5 });
+  const result = await syncGroupPlayers({ groupId, force: true });
+
+  logger.info("publicSyncGroupAction completed", {
+    groupId,
+    slug: group.slug,
+    attempted: result.attempted,
+    succeeded: result.succeeded,
+    failed: result.failed,
+    totalDue: result.totalDue,
+    errors: result.errors,
+  });
+
   await touchGroupManualSync({ groupId });
   revalidatePath(`/g/${group.slug}`);
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded `limit: 5` from `publicSyncGroupAction` so **all** group players sync when pressing "Actualizar ahora"
- Add structured logs throughout the sync flow for Vercel runtime visibility

## Changes
### `app/g/[slug]/actions.ts`
- Removed `limit: 5` — now calls `syncGroupPlayers({ groupId, force: true })` (processes all players)
- Captures `SyncResult` and logs it with `groupId`, `slug`, `attempted`, `succeeded`, `failed`, `totalDue`, `errors`

### `lib/riot/sync.ts` → `syncGroupPlayers()`
- Default limit changed from `DEFAULT_BATCH_SIZE` (5) to `duePlayers.length` (all) when no explicit limit is passed
- Added `syncGroupPlayers started` log with: `totalPlayers`, `duePlayers`, `batchSize`, `force`, `limitApplied`
- Added `syncGroupPlayers completed` log with full `SyncResult` breakdown
- Added `syncGroupPlayers aborted` log when group settings are missing

## What you'll see in Vercel logs after deploy
```
syncGroupPlayers started     → totalPlayers: 13, duePlayers: 13, batchSize: 13, force: true
Riot sync success            → (×N per player)
Riot sync failed             → (with specific error per player, if any)
syncGroupPlayers completed   → attempted: 13, succeeded: 12, failed: 1, errors: [...]
publicSyncGroupAction completed → same summary
```

## Risk
- 13 players × ~350ms API delay ≈ 5s, well within Vercel timeout (10s hobby / 60s pro)
- If group grows large (>25 players), may need an explicit limit — not a concern now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Mejoras de estabilidad**
  * Sincronización más robusta: ahora registra advertencias cuando faltan configuraciones de grupo en lugar de fallar silenciosamente
  * Optimización del procesamiento: los lotes se ajustan automáticamente según el número de jugadores pendientes
  * Mejor visibilidad de operaciones de sincronización con registros detallados de resultados

<!-- end of auto-generated comment: release notes by coderabbit.ai -->