### PR TITLE
fix(sync): refresh UI after manual sync without F5

### DIFF
--- a/app/g/[slug]/actions.ts
+++ b/app/g/[slug]/actions.ts
@@ -48,7 +48,18 @@ export async function publicSyncGroupAction(formData: FormData) {
     return;
   }
 
-  await syncGroupPlayers({ groupId, force: true, limit: 5 });
+  const result = await syncGroupPlayers({ groupId, force: true });
+
+  logger.info("publicSyncGroupAction completed", {
+    groupId,
+    slug: group.slug,
+    attempted: result.attempted,
+    succeeded: result.succeeded,
+    failed: result.failed,
+    totalDue: result.totalDue,
+    errors: result.errors,
+  });
+
   await touchGroupManualSync({ groupId });
   revalidatePath(`/g/${group.slug}`);
 }

--- a/app/g/[slug]/actions.ts
+++ b/app/g/[slug]/actions.ts
@@ -2,6 +2,7 @@
 
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
+import type { SyncActionState } from "@/app/g/[slug]/sync-types";
 import { isAdminEmail } from "@/lib/auth/admin";
 import {
   getGroupPlayers,
@@ -19,23 +20,26 @@ const PUBLIC_SYNC_COOLDOWN_MINUTES = 1;
 
 /**
  * Ejecuta un sync público para un grupo (cooldown 1 minuto).
- * @param formData - FormData con groupId.
+ * Compatible con useActionState: recibe (previousState, formData) y retorna SyncActionState.
  */
-export async function publicSyncGroupAction(formData: FormData) {
+export async function publicSyncGroupAction(
+  _previousState: SyncActionState,
+  formData: FormData,
+): Promise<SyncActionState> {
   const groupId = formData.get("groupId");
   if (typeof groupId !== "string" || !groupId) {
-    return;
+    return { status: "error", syncedAt: null };
   }
 
   const group = await getPublicGroupById(groupId);
   if (!group) {
     logger.warn("Public sync denied (group not public)", { groupId });
-    return;
+    return { status: "error", syncedAt: null };
   }
 
   const settings = await getGroupSyncSettings(groupId);
   if (!settings) {
-    return;
+    return { status: "error", syncedAt: null };
   }
 
   const allowed = isPast({
@@ -45,23 +49,30 @@ export async function publicSyncGroupAction(formData: FormData) {
 
   if (!allowed) {
     logger.info("Public sync cooldown not elapsed", { groupId });
-    return;
+    return { status: "cooldown", syncedAt: null };
   }
 
-  const result = await syncGroupPlayers({ groupId, force: true });
+  try {
+    const result = await syncGroupPlayers({ groupId, force: true });
 
-  logger.info("publicSyncGroupAction completed", {
-    groupId,
-    slug: group.slug,
-    attempted: result.attempted,
-    succeeded: result.succeeded,
-    failed: result.failed,
-    totalDue: result.totalDue,
-    errors: result.errors,
-  });
+    logger.info("publicSyncGroupAction completed", {
+      groupId,
+      slug: group.slug,
+      attempted: result.attempted,
+      succeeded: result.succeeded,
+      failed: result.failed,
+      totalDue: result.totalDue,
+      errors: result.errors,
+    });
 
-  await touchGroupManualSync({ groupId });
-  revalidatePath(`/g/${group.slug}`);
+    await touchGroupManualSync({ groupId });
+    revalidatePath(`/g/${group.slug}`);
+
+    return { status: "success", syncedAt: new Date().toISOString() };
+  } catch (error) {
+    logger.error("publicSyncGroupAction failed", { groupId, error });
+    return { status: "error", syncedAt: null };
+  }
 }
 
 /**

--- a/app/g/[slug]/actions.ts
+++ b/app/g/[slug]/actions.ts
@@ -49,7 +49,7 @@ export async function publicSyncGroupAction(
 
   if (!allowed) {
     logger.info("Public sync cooldown not elapsed", { groupId });
-    return { status: "cooldown", syncedAt: null };
+    return { status: "cooldown", syncedAt: settings.lastManualSyncAt };
   }
 
   try {

--- a/app/g/[slug]/public-sync-button.tsx
+++ b/app/g/[slug]/public-sync-button.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useActionState, useEffect, useMemo, useState } from "react";
+import { useFormStatus } from "react-dom";
+import type { SyncActionState } from "@/app/g/[slug]/sync-types";
+import { initialSyncActionState } from "@/app/g/[slug]/sync-types";
 import { Button } from "@/components/ui/button";
 
 type PublicSyncButtonProps = {
+  groupId: string;
   lastManualSyncAt: string | null;
   cooldownMinutes: number;
+  onSync: (
+    previousState: SyncActionState,
+    formData: FormData,
+  ) => Promise<SyncActionState>;
 };
 
 function getRemainingSeconds(params: {
@@ -24,36 +32,82 @@ function getRemainingSeconds(params: {
   return Math.max(0, Math.ceil(remainingMs / 1000));
 }
 
+/**
+ * Botón de sync público con useActionState.
+ * Gestiona el formulario, estado pendiente y cooldown.
+ */
 export function PublicSyncButton({
+  groupId,
   lastManualSyncAt,
   cooldownMinutes,
+  onSync,
 }: PublicSyncButtonProps) {
+  const [state, formAction] = useActionState(onSync, initialSyncActionState);
+
+  // Usar el timestamp más reciente entre el prop del server y el retornado por la action
+  const effectiveLastSync = useMemo(() => {
+    if (!state.syncedAt) return lastManualSyncAt;
+    if (!lastManualSyncAt) return state.syncedAt;
+    return Date.parse(state.syncedAt) > Date.parse(lastManualSyncAt)
+      ? state.syncedAt
+      : lastManualSyncAt;
+  }, [state.syncedAt, lastManualSyncAt]);
+
   const [remainingSeconds, setRemainingSeconds] = useState(() =>
-    getRemainingSeconds({ lastManualSyncAt, cooldownMinutes }),
+    getRemainingSeconds({
+      lastManualSyncAt: effectiveLastSync,
+      cooldownMinutes,
+    }),
   );
 
   useEffect(() => {
+    setRemainingSeconds(
+      getRemainingSeconds({
+        lastManualSyncAt: effectiveLastSync,
+        cooldownMinutes,
+      }),
+    );
+
     const interval = setInterval(() => {
       setRemainingSeconds(
-        getRemainingSeconds({ lastManualSyncAt, cooldownMinutes }),
+        getRemainingSeconds({
+          lastManualSyncAt: effectiveLastSync,
+          cooldownMinutes,
+        }),
       );
     }, 1000);
     return () => clearInterval(interval);
-  }, [lastManualSyncAt, cooldownMinutes]);
+  }, [effectiveLastSync, cooldownMinutes]);
 
-  const canSync = remainingSeconds === 0;
+  return (
+    <form action={formAction} className="flex items-center">
+      <input type="hidden" name="groupId" value={groupId} />
+      <SyncSubmitButton
+        canSync={remainingSeconds === 0}
+        remainingSeconds={remainingSeconds}
+      />
+    </form>
+  );
+}
+
+/** Botón submit interno que usa useFormStatus para detectar pending. */
+function SyncSubmitButton(props: {
+  canSync: boolean;
+  remainingSeconds: number;
+}) {
+  const { pending } = useFormStatus();
+
   const label = useMemo(() => {
-    if (canSync) {
-      return "Actualizar ahora";
-    }
-    return `Disponible en ${remainingSeconds}s`;
-  }, [canSync, remainingSeconds]);
+    if (pending) return "Sincronizando…";
+    if (props.canSync) return "Actualizar ahora";
+    return `Disponible en ${props.remainingSeconds}s`;
+  }, [pending, props.canSync, props.remainingSeconds]);
 
   return (
     <Button
       type="submit"
-      disabled={!canSync}
-      variant={canSync ? "outline" : "secondary"}
+      disabled={!props.canSync || pending}
+      variant={props.canSync && !pending ? "outline" : "secondary"}
       size="sm"
     >
       {label}

--- a/app/g/[slug]/sync-types.ts
+++ b/app/g/[slug]/sync-types.ts
@@ -1,0 +1,11 @@
+/** Estado retornado por publicSyncGroupAction para useActionState. */
+export type SyncActionState = {
+  status: "idle" | "success" | "cooldown" | "error";
+  syncedAt: string | null;
+};
+
+/** Estado inicial para useActionState. */
+export const initialSyncActionState: SyncActionState = {
+  status: "idle",
+  syncedAt: null,
+};

--- a/components/group/group-page-header.tsx
+++ b/components/group/group-page-header.tsx
@@ -1,11 +1,15 @@
 import { PublicSyncButton } from "@/app/g/[slug]/public-sync-button";
+import type { SyncActionState } from "@/app/g/[slug]/sync-types";
 
 type GroupPageHeaderProps = {
   groupId: string;
   groupName: string;
   lastManualSyncAt: string | null;
   cooldownMinutes: number;
-  onPublicSync: (formData: FormData) => void | Promise<void>;
+  onPublicSync: (
+    previousState: SyncActionState,
+    formData: FormData,
+  ) => Promise<SyncActionState>;
 };
 
 export function GroupPageHeader({
@@ -22,13 +26,12 @@ export function GroupPageHeader({
           {groupName}
         </h1>
       </div>
-      <form action={onPublicSync} className="flex items-center">
-        <input type="hidden" name="groupId" value={groupId} />
-        <PublicSyncButton
-          lastManualSyncAt={lastManualSyncAt}
-          cooldownMinutes={cooldownMinutes}
-        />
-      </form>
+      <PublicSyncButton
+        groupId={groupId}
+        lastManualSyncAt={lastManualSyncAt}
+        cooldownMinutes={cooldownMinutes}
+        onSync={onPublicSync}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes the bug where clicking "Actualizar ahora" on `/g/[slug]` ran the sync successfully but didn't refresh the players table — required manual F5
- Converts `publicSyncGroupAction` to `useActionState` pattern (React 19), matching the existing pattern in `app/admin/groups-table.tsx`

## Changes
- **`app/g/[slug]/sync-types.ts`** (NEW): Extract `SyncActionState` type + `initialSyncActionState` — needed because `"use server"` files can only export async functions
- **`app/g/[slug]/actions.ts`**: Return typed state (`success`/`cooldown`/`error`) from server action + add try/catch to prevent hung UI
- **`app/g/[slug]/public-sync-button.tsx`**: Owns `<form>` with `useActionState` + `useFormStatus`, computes cooldown from `max(action response, server prop)`
- **`components/group/group-page-header.tsx`**: Simplified — delegates form rendering to `PublicSyncButton`

## How to test
1. Go to `/g/<any-group>`
2. Click "Actualizar ahora"
3. Should show "Sincronizando…" then refresh table data **without F5**
4. Cooldown timer starts immediately after sync completes
5. Button re-enables after 60s

## Verification
- `bun run lint` ✅
- `bun run test` ✅ (12 suites, 47 tests)
- `bun run build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Mejoras**
  * Sincronización de grupos ahora devuelve y gestiona estados explícitos (idle/success/cooldown/error) para feedback consistente.
  * Lógica de espera y recálculo de tiempos usa un estado efectivo combinado entre servidor y cliente.

* **Nuevas funciones**
  * Botón de sincronización actualizado: muestra estados dinámicos ("Sincronizando…", "Actualizar ahora", "Disponible en Xs") y se desactiva correctamente durante la operación.

* **Chores**
  * Interfaz pública actualizada para soportar el flujo de estado asincrónico.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->